### PR TITLE
Implement jupyter notebook titles extraction

### DIFF
--- a/preparar_notebook/src/jupyter_notebook_tittles.py
+++ b/preparar_notebook/src/jupyter_notebook_tittles.py
@@ -1,0 +1,19 @@
+import json
+import re
+
+
+def get_notebook_tittles(notebook_path):
+    with open(notebook_path, 'r') as file:
+        notebook_json = json.load(file)
+
+    tittles = []
+    for cell in notebook_json.get('cells', []):
+        if cell.get('cell_type') == 'markdown':
+            for line in cell.get('source', []):
+                line_stripped = line.rstrip()
+                match = re.match(r'^\s{0,3}(#{1,6})\s+(.*)$', line_stripped)
+                if match:
+                    level = f"h{len(match.group(1))}"
+                    text = match.group(2).strip()
+                    tittles.append({'text': text, 'level': level})
+    return tittles

--- a/preparar_notebook/tests/test_jupyter_notebook_tittles.py
+++ b/preparar_notebook/tests/test_jupyter_notebook_tittles.py
@@ -1,0 +1,19 @@
+import unittest
+from preparar_notebook.src.jupyter_notebook_tittles import get_notebook_tittles
+
+
+class Test_jupyter_notebook_tittles(unittest.TestCase):
+    def setUp(self):
+        self.notebook = "preparar_notebook/tests/test_get_notebook_metadata.ipynb"
+
+    def test_number_of_tittles(self):
+        tittles = get_notebook_tittles(self.notebook)
+        self.assertEqual(len(tittles), 91)
+
+    def test_some_tittles(self):
+        tittles = get_notebook_tittles(self.notebook)
+        self.assertEqual(tittles[0], {"text": "Introducción a Python", "level": "h1"})
+        self.assertEqual(tittles[1], {"text": "1. Resumen", "level": "h2"})
+        self.assertEqual(tittles[2], {"text": "2. Tipos de datos de Python", "level": "h2"})
+        self.assertEqual(tittles[3], {"text": "2.1. Strings", "level": "h3"})
+        self.assertEqual(tittles[-1], {"text": "14. El Zen de Python", "level": "h2"})


### PR DESCRIPTION
## Summary
- add helper to extract all titles from a notebook
- test titles extraction logic

## Testing
- `bash pass_tests.sh` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_68440a01cafc83219d29f3801624d704