### PR TITLE
feat: Add script to extract titles from Jupyter Notebooks

### DIFF
--- a/preparar_notebook/src/jupyter_notebook_tittles.py
+++ b/preparar_notebook/src/jupyter_notebook_tittles.py
@@ -1,0 +1,77 @@
+import json
+
+def extract_titles(notebook_path):
+    """
+    Extracts titles and their levels from a Jupyter Notebook.
+
+    Args:
+        notebook_path (str): The path to the Jupyter Notebook file.
+
+    Returns:
+        list: A list of dictionaries, where each dictionary contains
+              'text' (the title string) and 'level' (e.g., 'h1', 'h2').
+              Returns an empty list if an error occurs.
+    """
+    titles = []
+    try:
+        with open(notebook_path, 'r', encoding='utf-8') as f:
+            notebook_content = json.load(f)
+
+        for cell in notebook_content.get('cells', []):
+            if cell.get('cell_type') == 'markdown':
+                # Ensure source is iterable and handle None case
+                cell_source = cell.get('source') or []
+                for item in cell_source: # item can be a string or a list of strings (though typically a string)
+                    # Ensure item is a string before calling splitlines
+                    if isinstance(item, str):
+                        for line in item.splitlines():
+                            line_stripped = line.lstrip()
+                            if line_stripped.startswith('#'):
+                                level = 0
+                                for char in line_stripped:
+                                    if char == '#':
+                                        level += 1
+                                    else:
+                                        break
+                                # Ensure there's a space after the hashes
+                                if level > 0 and len(line_stripped) > level and line_stripped[level] == ' ':
+                                    title_text = line_stripped[level:].strip() # Use strip() for cleaner text
+                                    if title_text: # Ensure title is not empty
+                                        titles.append({'text': title_text, 'level': f'h{level}'})
+    except FileNotFoundError:
+        print(f"Error: File not found at {notebook_path}")
+        return []
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON from {notebook_path}")
+        return []
+    return titles
+
+if __name__ == '__main__':
+    # Test with a dummy notebook expected to be in the same directory
+    dummy_notebook_path = 'dummy_notebook.ipynb'
+    # Attempt to create a dummy notebook for testing if it doesn't exist
+    # (this is simplified for the subtask; ideally, the file is pre-created)
+    import os
+    if not os.path.exists(dummy_notebook_path):
+        print(f"Warning: Dummy notebook {dummy_notebook_path} not found. Test might not run as expected.")
+        # In a real scenario, you might skip the test or ensure the file is created.
+        # For this subtask, we assume the file creation step (1) is done by the subtask runner.
+
+    print(f"Extracting titles from: {dummy_notebook_path}")
+    titles = extract_titles(dummy_notebook_path)
+    if titles:
+        print("Extracted titles:")
+        for title in titles:
+            print(f"- Level: {title['level']}, Text: {title['text']}")
+    else:
+        print("No titles extracted or an error occurred.")
+
+    # Test with a non-existent notebook
+    print("\nExtracting titles from: non_existent_notebook.ipynb")
+    titles_non_existent = extract_titles("non_existent_notebook.ipynb")
+    if titles_non_existent:
+        print("Extracted titles:")
+        for title in titles_non_existent:
+            print(f"- Level: {title['level']}, Text: {title['text']}")
+    else:
+        print("No titles extracted or an error occurred (as expected for a non-existent file).")

--- a/preparar_notebook/tests/test_jupyter_notebook_tittles.py
+++ b/preparar_notebook/tests/test_jupyter_notebook_tittles.py
@@ -1,0 +1,116 @@
+import unittest
+import json
+import os
+import sys
+
+# Add the src directory to sys.path to allow importing jupyter_notebook_tittles
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from jupyter_notebook_tittles import extract_titles
+
+class TestExtractTitles(unittest.TestCase):
+
+    def setUp(self):
+        # Create dummy notebook files for testing
+        self.test_dir = os.path.dirname(__file__)
+        self.notebook_with_titles_path = os.path.join(self.test_dir, 'test_notebook_with_titles.ipynb')
+        self.notebook_no_titles_path = os.path.join(self.test_dir, 'test_notebook_no_titles.ipynb')
+        self.notebook_empty_cells_path = os.path.join(self.test_dir, 'test_notebook_empty_cells.ipynb')
+        self.notebook_malformed_json_path = os.path.join(self.test_dir, 'test_notebook_malformed.ipynb')
+
+        # Notebook with various titles
+        notebook_content_with_titles = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["# Title H1"]},
+                {"cell_type": "code", "source": ["print('hello')"]},
+                {"cell_type": "markdown", "source": ["## Title H2"]},
+                {"cell_type": "markdown", "source": ["### Title H3 with spaces  "]},
+                {"cell_type": "markdown", "source": ["    #### Indented H4"]},
+                {"cell_type": "markdown", "source": ["##### Title H5\nMore text"]},
+                {"cell_type": "markdown", "source": ["###### Title H6"]},
+                {"cell_type": "markdown", "source": ["Not a title"]},
+                {"cell_type": "markdown", "source": ["#Another H1 but no space"]}, # Should not be matched
+                {"cell_type": "markdown", "source": ["# Valid H1\n## Also Valid H2 in same cell"]}
+            ],
+            "nbformat": 4, "nbformat_minor": 2
+        }
+        with open(self.notebook_with_titles_path, 'w') as f:
+            json.dump(notebook_content_with_titles, f)
+
+        # Notebook with no titles
+        notebook_content_no_titles = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["Just some text."]},
+                {"cell_type": "code", "source": ["a = 1"]},
+                {"cell_type": "markdown", "source": ["Another paragraph."]}
+            ],
+            "nbformat": 4, "nbformat_minor": 2
+        }
+        with open(self.notebook_no_titles_path, 'w') as f:
+            json.dump(notebook_content_no_titles, f)
+
+        # Notebook with empty or no source in markdown cells
+        notebook_content_empty_cells = {
+            "cells": [
+                {"cell_type": "markdown", "source": []},
+                {"cell_type": "markdown", "source": None}, # Source might be None
+                {"cell_type": "markdown", "metadata": {}, "source": ["# A title here"]},
+                {"cell_type": "markdown"} # Cell with no source key
+            ],
+            "nbformat": 4, "nbformat_minor": 2
+        }
+        with open(self.notebook_empty_cells_path, 'w') as f:
+            json.dump(notebook_content_empty_cells, f)
+
+        # Malformed JSON file
+        with open(self.notebook_malformed_json_path, 'w') as f:
+            f.write("this is not valid json")
+
+    def tearDown(self):
+        # Clean up dummy files
+        os.remove(self.notebook_with_titles_path)
+        os.remove(self.notebook_no_titles_path)
+        os.remove(self.notebook_empty_cells_path)
+        os.remove(self.notebook_malformed_json_path)
+        # Remove dummy_notebook.ipynb from src if it exists from previous step
+        src_dummy_notebook = os.path.join(self.test_dir, '../src/dummy_notebook.ipynb')
+        if os.path.exists(src_dummy_notebook):
+            os.remove(src_dummy_notebook)
+
+
+    def test_notebook_with_various_titles(self):
+        expected_titles = [
+            {'text': 'Title H1', 'level': 'h1'},
+            {'text': 'Title H2', 'level': 'h2'},
+            {'text': 'Title H3 with spaces', 'level': 'h3'},
+            {'text': 'Indented H4', 'level': 'h4'},
+            {'text': 'Title H5', 'level': 'h5'},
+            {'text': 'Title H6', 'level': 'h6'},
+            {'text': 'Valid H1', 'level': 'h1'},
+            {'text': 'Also Valid H2 in same cell', 'level': 'h2'}
+        ]
+        titles = extract_titles(self.notebook_with_titles_path)
+        self.assertEqual(titles, expected_titles)
+
+    def test_notebook_with_no_titles(self):
+        titles = extract_titles(self.notebook_no_titles_path)
+        self.assertEqual(titles, [])
+
+    def test_non_existent_notebook(self):
+        # Redirect stdout to check print message for error
+        # For now, just check if it returns an empty list as per current implementation
+        titles = extract_titles("non_existent_notebook.ipynb")
+        self.assertEqual(titles, [])
+        # Add assertion for printed error message if possible, or ensure logging in actual function
+
+    def test_notebook_with_empty_and_missing_source_cells(self):
+        expected_titles = [{'text': 'A title here', 'level': 'h1'}]
+        titles = extract_titles(self.notebook_empty_cells_path)
+        self.assertEqual(titles, expected_titles)
+
+    def test_malformed_json_notebook(self):
+        titles = extract_titles(self.notebook_malformed_json_path)
+        self.assertEqual(titles, [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a new script `preparar_notebook/src/jupyter_notebook_tittles.py` which contains a function `extract_titles`. This function takes the path to a Jupyter Notebook file and returns a list of dictionaries, each containing the text and level (e.g., h1, h2) of a title found in the notebook's markdown cells.

The implementation handles:
- Reading and parsing the notebook's JSON structure.
- Identifying markdown cells and lines starting with '#' characters.
- Correctly determining title level based on the number of '#'.
- Extracting clean title text.
- Handling cases like empty or malformed notebooks, and cells with no source.

Unit tests have been added in `preparar_notebook/tests/test_jupyter_notebook_tittles.py` to cover various scenarios, ensuring the function's reliability. The tests helped identify and fix initial bugs related to source handling and text stripping.