### PR TITLE
Add notebook XML converter

### DIFF
--- a/preparar_notebook/src/jupyter_notebook_to_xml.py
+++ b/preparar_notebook/src/jupyter_notebook_to_xml.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+import pathlib
+import xml.etree.ElementTree as ET
+
+
+def notebook_to_xml_tree(notebook_path):
+    """Return an ElementTree representing the notebook converted to XML."""
+    with open(notebook_path, 'r', encoding='utf-8') as f:
+        notebook_json = json.load(f)
+
+    root = ET.Element('notebook')
+
+    for cell in notebook_json.get('cells', []):
+        cell_type = cell.get('cell_type')
+        if cell_type == 'markdown':
+            md = ''.join(cell.get('source', []))
+            elem = ET.SubElement(root, 'markdown')
+            elem.text = md
+        elif cell_type == 'code':
+            input_code = ''.join(cell.get('source', []))
+            input_elem = ET.SubElement(root, 'input_code')
+            input_elem.text = input_code
+            for output in cell.get('outputs', []):
+                output_text = ''
+                if isinstance(output, dict):
+                    if 'text' in output:
+                        value = output['text']
+                        if isinstance(value, list):
+                            output_text = ''.join(value)
+                        else:
+                            output_text = str(value)
+                    elif 'data' in output:
+                        data = output['data']
+                        if isinstance(data, dict):
+                            if 'text/plain' in data:
+                                value = data['text/plain']
+                                if isinstance(value, list):
+                                    output_text = ''.join(value)
+                                else:
+                                    output_text = str(value)
+                            else:
+                                output_text = json.dumps(data)
+                        else:
+                            output_text = str(data)
+                    elif 'name' in output and 'text' in output:
+                        value = output['text']
+                        if isinstance(value, list):
+                            output_text = ''.join(value)
+                        else:
+                            output_text = str(value)
+                    elif 'traceback' in output:
+                        tb = output['traceback']
+                        if isinstance(tb, list):
+                            output_text = ''.join(tb)
+                        else:
+                            output_text = str(tb)
+                    else:
+                        output_text = str(output)
+                else:
+                    output_text = str(output)
+                out_elem = ET.SubElement(root, 'output_code')
+                out_elem.text = output_text
+    return ET.ElementTree(root)
+
+
+def convert_notebook_to_xml(notebook_path):
+    """Convert a Jupyter notebook to XML and save it in xml_files folder."""
+    notebook_path = pathlib.Path(notebook_path)
+    xml_tree = notebook_to_xml_tree(notebook_path)
+
+    xml_dir = notebook_path.parent / 'xml_files'
+    xml_dir.mkdir(exist_ok=True)
+    xml_file = xml_dir / f"{notebook_path.stem}.xml"
+    xml_tree.write(xml_file, encoding='utf-8', xml_declaration=True)
+    return xml_file
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Convert Jupyter notebook to XML')
+    parser.add_argument('notebook_path', help='Path to the Jupyter notebook')
+    args = parser.parse_args()
+
+    convert_notebook_to_xml(args.notebook_path)

--- a/preparar_notebook/tests/test_jupyter_notebook_to_xml.py
+++ b/preparar_notebook/tests/test_jupyter_notebook_to_xml.py
@@ -1,0 +1,51 @@
+import os
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from jupyter_notebook_to_xml import convert_notebook_to_xml
+
+class TestJupyterNotebookToXml(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.nb_path = self.tmpdir / 'test_notebook.ipynb'
+        notebook_content = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["# Title"]},
+                {
+                    "cell_type": "code",
+                    "source": ["print('hi')"],
+                    "outputs": [
+                        {"output_type": "stream", "name": "stdout", "text": ["hi\n"]}
+                    ]
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 2
+        }
+        with open(self.nb_path, 'w') as f:
+            json.dump(notebook_content, f)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_convert_notebook_to_xml(self):
+        xml_file = convert_notebook_to_xml(str(self.nb_path))
+        self.assertTrue(xml_file.exists())
+        import xml.etree.ElementTree as ET
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        tags = [child.tag for child in root]
+        self.assertEqual(tags, ['markdown', 'input_code', 'output_code'])
+        self.assertEqual(root.find('markdown').text, '# Title')
+        self.assertEqual(root.find('input_code').text, "print('hi')")
+        self.assertEqual(root.find('output_code').text, 'hi\n')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert notebooks to XML format with new script
- add unit test for notebook-to-XML conversion

## Testing
- `bash pass_tests.sh` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6849a97c7f948321bf618c1ac8af42a3