### PR TITLE
feat: Add jupyter_notebook_to_xml.py script

### DIFF
--- a/preparar_notebook/src/jupyter_notebook_to_xml.py
+++ b/preparar_notebook/src/jupyter_notebook_to_xml.py
@@ -1,0 +1,109 @@
+import json
+import xml.etree.ElementTree as ET
+import sys
+import argparse
+import os
+
+def convert_notebook_to_xml(notebook_path):
+    """
+    Converts a Jupyter notebook to XML format.
+    The XML file will be saved in a subdirectory named 'xml_files'
+    in the same directory as the input notebook.
+
+    Args:
+        notebook_path (str): The path to the Jupyter notebook file.
+    """
+    try:
+        notebook_dir = os.path.dirname(os.path.abspath(notebook_path))
+        notebook_filename = os.path.basename(notebook_path)
+        notebook_name_without_ext = os.path.splitext(notebook_filename)[0]
+
+        xml_dir = os.path.join(notebook_dir, "xml_files")
+        if not os.path.exists(xml_dir):
+            try:
+                os.makedirs(xml_dir)
+                print(f"Created directory: {xml_dir}")
+            except OSError as e:
+                print(f"Error: Could not create directory {xml_dir}. {e}")
+                return
+
+        xml_filename = f"{notebook_name_without_ext}.xml"
+        xml_path = os.path.join(xml_dir, xml_filename)
+
+    except Exception as e:
+        print(f"Error processing paths: {e}")
+        return
+
+    try:
+        with open(notebook_path, 'r', encoding='utf-8') as f:
+            notebook_content = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: Notebook file not found at {notebook_path}")
+        return
+    except json.JSONDecodeError:
+        print(f"Error: Invalid JSON format in notebook file {notebook_path}")
+        return
+
+    root = ET.Element("notebook")
+
+    for cell in notebook_content.get("cells", []):
+        cell_type = cell.get("cell_type")
+        source_list = cell.get("source", [])
+        source = "".join(source_list)
+
+        if cell_type == "markdown":
+            markdown_element = ET.SubElement(root, "markdown")
+            markdown_element.text = source
+        elif cell_type == "code":
+            input_code_element = ET.SubElement(root, "input_code")
+            input_code_element.text = source
+
+            for output in cell.get("outputs", []):
+                output_text_content = ""
+                output_type = output.get("output_type")
+
+                if output_type == "stream":
+                    text_data = output.get("text", [])
+                    if isinstance(text_data, list):
+                        output_text_content = "".join(text_data)
+                    elif isinstance(text_data, str):
+                        output_text_content = text_data
+                elif output_type in ["execute_result", "display_data"]:
+                    text_data = output.get("data", {}).get("text/plain", [])
+                    if isinstance(text_data, list):
+                        output_text_content = "".join(text_data)
+                    elif isinstance(text_data, str):
+                        output_text_content = text_data
+
+                # Ensure newline characters are preserved if source is a list of lines
+                # and also handle cases where text_data might already be a pre-joined string.
+                if isinstance(source_list, list) and '\n' not in output_text_content and len(source_list) > 0 :
+                    # This check is a bit heuristic. If text_data was a list of lines, "".join would keep newlines if they were there.
+                    # If it was a single string from text/plain, it might or might not have newlines.
+                    # The primary goal is to join list of strings with newlines if text_data itself was a list of strings.
+                    # The current join "".join(text_data) above handles this.
+                    # This part might need refinement based on more diverse notebook examples.
+                    pass
+
+
+                output_code_element = ET.SubElement(root, "output_code")
+                output_code_element.text = output_text_content.strip('\n') # Strip trailing newlines from output
+        # Other cell types are ignored
+
+    tree = ET.ElementTree(root)
+    try:
+        tree.write(xml_path, encoding="utf-8", xml_declaration=True)
+        print(f"Notebook converted successfully to {xml_path}")
+    except IOError:
+        print(f"Error: Could not write XML file to {xml_path}")
+    except Exception as e:
+        print(f"An unexpected error occurred during XML writing: {e}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert a Jupyter notebook to XML format.")
+    parser.add_argument("notebook_path", help="The path to the Jupyter notebook file (.ipynb).")
+
+    args = parser.parse_args()
+
+    convert_notebook_to_xml(args.notebook_path)

--- a/test_notebook.ipynb
+++ b/test_notebook.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Hello, world!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a markdown cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = 1\n",
+    "b = 2\n",
+    "print(a + b)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_notebook_with_outputs.ipynb
+++ b/test_notebook_with_outputs.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a **markdown** cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = 10\n",
+    "b = 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello from stream output!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Hello from stream output!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a + b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Line 1\n",
+      "Line 2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error message on stderr\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Line 1\")\n",
+    "print(\"Line 2\")\n",
+    "import sys\n",
+    "sys.stderr.write(\"Error message on stderr\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Example of display_data with text/plain\n",
+    "from IPython.display import display, Image\n",
+    "display({'text/plain': '<Figure size 640x480 with 1 Axes>', 'image/png': 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='}, raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This cell intentionally only has an image output to test empty output_code\n",
+    "from IPython.display import Image\n",
+    "Image(data='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "This is a raw cell and should be ignored."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_output.xml
+++ b/test_output.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<notebook><cell type="code">print("Hello, world!")</cell><cell type="markdown">This is a markdown cell.</cell><cell type="code">a = 1
+b = 2
+print(a + b)</cell></notebook>

--- a/xml_files/test_notebook.xml
+++ b/xml_files/test_notebook.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<notebook><code type="code">print("Hello, world!")</code><markdown>This is a markdown cell.</markdown><code type="code">a = 1
+b = 2
+print(a + b)</code></notebook>

--- a/xml_files/test_notebook_with_outputs.xml
+++ b/xml_files/test_notebook_with_outputs.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<notebook><markdown>This is a **markdown** cell.</markdown><input_code>a = 10
+b = 5</input_code><input_code>print("Hello from stream output!")</input_code><output_code>Hello from stream output!</output_code><input_code>a + b</input_code><output_code>15</output_code><input_code>print("Line 1")
+print("Line 2")
+import sys
+sys.stderr.write("Error message on stderr\n")</input_code><output_code>Line 1
+Line 2</output_code><output_code>Error message on stderr</output_code><input_code># Example of display_data with text/plain
+from IPython.display import display, Image
+display({'text/plain': '&lt;Figure size 640x480 with 1 Axes&gt;', 'image/png': 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='}, raw=True)</input_code><output_code>&lt;Figure size 640x480 with 1 Axes&gt;</output_code><input_code># This cell intentionally only has an image output to test empty output_code
+from IPython.display import Image
+Image(data='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')</input_code><output_code /></notebook>


### PR DESCRIPTION
This script converts Jupyter Notebook (.ipynb) files to XML format.

Key features:
- Takes a notebook file path as input.
- Creates an 'xml_files' directory in the notebook's location if it doesn't exist.
- Saves the generated XML in this directory with the same name as the notebook.
- Converts markdown cells to `<markdown>` tags.
- Converts code cells to `<input_code>` tags for the source code.
- Extracts outputs from code cells (stream, execute_result, display_data focusing on text/plain) into separate `<output_code>` tags for each output.
- Includes error handling for file operations and JSON parsing.